### PR TITLE
Proposed fix to test script (t/09-unicode.t)

### DIFF
--- a/t/09-unicode.t
+++ b/t/09-unicode.t
@@ -114,7 +114,7 @@ cmp_deeply(
 diag 'extracted contributors: ', explain $tzil->distmeta->{x_contributors}
     if $^O eq 'MSWin32';
 
-diag('got log messages: ', explain $tzil->log_messages
+diag('got log messages: ', explain $tzil->log_messages)
     if not Test::Builder->new->is_passing;
 
 done_testing;


### PR DESCRIPTION
Hi Karen,

Please review the proposed change to fix the following error:

t/08-order-by.t ................ ok
syntax error at t/09-unicode.t line 118, near "->log_messages
    if"
Execution of t/09-unicode.t aborted due to compilation errors.

Many Thanks.

Best Regards,
Mohammad S Anwar