### PR TITLE
- Propose fix to remove duplicate entries from the contributors list.

### DIFF
--- a/lib/Dist/Zilla/Plugin/Git/Contributors.pm
+++ b/lib/Dist/Zilla/Plugin/Git/Contributors.pm
@@ -140,7 +140,15 @@ sub _contributors
         } @contributors;
     }
 
-    return \@contributors;
+    # preserve the order to keep existing unit test happy.
+    my @unique_contributors;
+    my $seen_contributors;
+    foreach (@contributors) {
+        next if (exists $seen_contributors->{uc($_)});
+        push @unique_contributors, $_;
+        $seen_contributors->{uc($_)} = 1;
+    }
+    return \@unique_contributors;
 }
 
 sub _releaser


### PR DESCRIPTION
Hi Karen,

I noticed the contributors list generated by Dist::Zilla::Plugin::Git::Contributors v0.015 has duplicate entries. It seems it is case sensitive list. When I ran dzil build against package Email::Valid v1.199
I got duplicate entries like "Ricardo SIGNES <rjbs@cpan.org>" and "Ricardo Signes <rjbs@cpan.org>". As you see they exactly the same, I propose to remove duplicate entries in this PR.

Please review the changes.

Many Thanks.

Best Regards,
Mohammad S Anwar