### PR TITLE
- Remove warning thrown by Path::Tiny during unit test.

### DIFF
--- a/lib/Dist/Zilla/Plugin/Git/Contributors.pm
+++ b/lib/Dist/Zilla/Plugin/Git/Contributors.pm
@@ -13,7 +13,7 @@ with 'Dist::Zilla::Role::MetaProvider';
 use List::Util 1.33 'none';
 use Git::Wrapper 0.035;
 use Try::Tiny;
-use Path::Tiny 0.048;
+use Path::Tiny 0.071;
 use Moose::Util::TypeConstraints 'enum';
 use List::UtilsBy 0.04 'uniq_by';
 use Unicode::Collate 0.53;


### PR DESCRIPTION
Hi Karen,

When running unit test for Dist::Zilla::Plugin::Git::Contributors v0.016, I am getting the following warnings thrown by Path::Tiny. 

t/11-paths.t ................... 1/? # testing with git repo /tmp/zkoemmBgg9/zAvEZN9HES/source
# Testing with git version: 2.3.7
Unrecognized option(s) passed to make_path(): err at /usr/local/share/perl/5.10.1/Path/Tiny.pm line 1117.
Unrecognized option(s) passed to make_path(): err at /usr/local/share/perl/5.10.1/Path/Tiny.pm line 1117.
t/11-paths.t ................... ok   

In my test box, I have Path::Tiny v0.070, which is acceptable as the distribution expected minimum version is Path::Tiny v0.048.

Having checked the change logs for Path::Tiny, I found that the warning is removed in the 
Path::Tiny v0.071 as the change log says:

0.071     2015-07-17 13:40:08-04:00 America/New_York (TRIAL RELEASE)
 
    [FIXED]
 
    - Fixed incorrect error argument for File::Path functions
      (mkpath and remove_tree)

Therefore I propose to upgrade the minimum version of Path::Tiny to v0.71, if there is no
other side effects.

Many Thanks.

Best Regards,
Mohammad S Anwar