### PR TITLE
In t/lib/GitSetup.pm, the test doesn't work as intended under Win32

### DIFF
--- a/t/lib/GitSetup.pm
+++ b/t/lib/GitSetup.pm
@@ -30,11 +30,12 @@ sub no_git_tempdir
                 $in_git = 1;
                 last;
             }
+            last if $dir eq $dir->parent;
             $dir = $dir->parent;
         }
         continue {
             die "too many iterations when traversing $tempdir!"
-                if $count++ > 100;
+                if $count++ > 98;
         }
 
         ok(!$in_git, 'tempdir is not in a real git repository');


### PR DESCRIPTION
I found, what I think, is a problem in test t/lib/GitSetup.pm under Win32. Please consider kindly my patch.

   while ($dir ne $rootdir and $count < 100) {...}
   continue { die if $count++ > 100; }

There are two things to consider:

First, under Win32, the real root dir usually is "C:\".
However, the variable $rootdir appears to be "/", as a consequence,
the condition "...$dir ne $rootdir..." will forever be true.
To improve that situation, an additional "...last if $dir eq $dir->parent..."
has been added to the body of the while loop.

Secondly, the condition "...die if $count++ > 100..." in the continue-block
can never be true, as the loop is exited when $count == 100. In order to
trigger the condition, we have to change it to "...die if $count++ > 98...".