### PR TITLE
Compare authors/contributors/releasers case-insensitively

### DIFF
--- a/lib/Dist/Zilla/Plugin/Git/Contributors.pm
+++ b/lib/Dist/Zilla/Plugin/Git/Contributors.pm
@@ -175,7 +175,7 @@ sub _build_contributors
         sub { require Data::Dumper; Data::Dumper->new([ \@contributors ])->Indent(2)->Terse(1)->Dump } ]);
 
     # remove duplicates by email address, keeping the latest associated name
-    @contributors = uniq_by { (/(<[^>]+>)/g)[-1] } @contributors;
+    @contributors = uniq_by { lc((/(<[^>]+>)/g)[-1]) } @contributors;
 
     @contributors = Unicode::Collate->new(level => 1)->sort(@contributors) if $self->order_by eq 'name';
 
@@ -184,13 +184,13 @@ sub _build_contributors
         my @author_emails = map { /(<[^>]+>)/g } @{ $self->zilla->authors };
         @contributors = grep {
             my $contributor = $_;
-            none { $contributor =~ /\Q$_\E/ } @author_emails;
+            none { $contributor =~ /\Q$_\E/i } @author_emails;
         } @contributors;
     }
 
     if (not $self->include_releaser and my $releaser = $self->_releaser)
     {
-        @contributors = grep { $_ ne $releaser } @contributors;
+        @contributors = grep { lc $_ ne lc $releaser } @contributors;
     }
 
     if ($self->remove)

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -22,6 +22,7 @@ my $tzil = Builder->from_config(
                         'Anon Y. Moose <anon@null.com>',
                         'Anne O\'Thor <author@example.com>',
                         'Tokuhiro Matsuno <tokuhirom @*(#RJKLFHFSDLJF gmail.com>',
+                        'Yon Knight <yknight@Example.com>',
                     ],
                 },
                 [ GatherDir => ],
@@ -50,6 +51,16 @@ $changes->append("- another changelog entry\n");
 $git->add('Changes');
 $git->commit({ message => 'third commit', author => 'Foo Bar <foo@bar.com>' });
 
+# case difference in email
+$changes->append("- another changelog entry\n");
+$git->add('Changes');
+$git->commit({ message => 'third commit', author => 'Foo Bar <Foo@bar.com>' });
+
+# case difference in email
+$changes->append("- another changelog entry\n");
+$git->add('Changes');
+$git->commit({ message => 'third commit', author => 'Yon Knight <yknight@example.com>', });
+
 $tzil->chrome->logger->set_debug(1);
 
 is(
@@ -62,7 +73,7 @@ cmp_deeply(
     $tzil->distmeta,
     superhashof({
         x_contributors => [
-            'Foo Bar <foo@bar.com>',
+            'Foo Bar <Foo@bar.com>',
             'Hey Jude <jude@example.org>',
         ],
         x_Dist_Zilla => superhashof({

--- a/t/06-include-releaser.t
+++ b/t/06-include-releaser.t
@@ -33,6 +33,7 @@ my $tzil = Builder->from_config(
 my $root = path($tzil->tempdir)->child('source');
 my $git = git_wrapper($root);
 
+# upper case here
 my $releaser = 'Test User <test@example.com>';
 
 my $changes = $root->child('Changes');
@@ -43,6 +44,10 @@ $git->commit({ message => 'first commit', author => $tzil->authors->[0] });
 $changes->append("- a changelog entry\n");
 $git->add('Changes');
 $git->commit({ message => 'second commit', author => $releaser });
+
+$changes->append("- a changelog entry\n");
+$git->add('Changes');
+$git->commit({ message => 'second commit', author => lc $releaser }); # lowercase here
 
 $changes->append("- a changelog entry\n");
 $git->add('Changes');


### PR DESCRIPTION
This way you don't end up with yourself in AUTHOR and CONTRIBUTOR if your dist.ini and git config don't agree about the case of your email address.