### PR TITLE
Disable automatic gpg signing of commits

### DIFF
--- a/t/lib/GitSetup.pm
+++ b/t/lib/GitSetup.pm
@@ -46,13 +46,14 @@ sub no_git_tempdir
 }
 
 # adds --no-verify to all 'git commit' commands, to avoid triggering any
-# globally-configured pre-commit hooks.
+# globally-configured pre-commit hooks, and disable any globally configured 
+# automatic gpg signing
 {
     package My::Git::Wrapper;
     use parent 'Git::Wrapper';
 
     sub commit {
-        return shift->RUN(commit => @_, { 'no-verify' => 1 });
+        return shift->RUN(commit => @_, { 'no-verify' => 1, '-c' => 'commit.gpgsign=false' });
     }
 }
 


### PR DESCRIPTION
There's a git [config option](https://git-scm.com/docs/git-config#git-config-commitgpgSign) to gpg sign all commits, which requires interactive prompts causing test failures like [this](http://www.cpantesters.org/cpan/report/58d709c8-b2b7-11e7-af8a-d0ec1e117d75).

This patch sets that option to false to the tests can pass.

Thanks!